### PR TITLE
add nmr and imr for log logistic

### DIFF
--- a/R/surv_synthetic.R
+++ b/R/surv_synthetic.R
@@ -773,8 +773,12 @@ surv_synthetic <- function(df,
       
       # add u5mr, nmr, imr to ret_df
       ret_df$U5MR <- NA
+      ret_df$NMR <- NA
+      ref_df$IMR <- NA
       for (i in 1:nrow(ret_df)) {
         ret_df$U5MR[i] <- rcpp_F_loglogistic(60, shape = exp(ret_df$log_shape_mean[i]), scale = exp(ret_df$log_scale_mean[i]), 1, 0)
+        ret_df$NMR[i] <- rcpp_F_loglogistic(1, shape = exp(ret_df$log_shape_mean[i]), scale = exp(ret_df$log_scale_mean[i]), 1, 0)
+        ret_df$IMR[i] <- rcpp_F_loglogistic(12, shape = exp(ret_df$log_shape_mean[i]), scale = exp(ret_df$log_scale_mean[i]), 1, 0)
       }
     }
     

--- a/R/surv_synthetic.R
+++ b/R/surv_synthetic.R
@@ -774,7 +774,7 @@ surv_synthetic <- function(df,
       # add u5mr, nmr, imr to ret_df
       ret_df$U5MR <- NA
       ret_df$NMR <- NA
-      ref_df$IMR <- NA
+      ret_df$IMR <- NA
       for (i in 1:nrow(ret_df)) {
         ret_df$U5MR[i] <- rcpp_F_loglogistic(60, shape = exp(ret_df$log_shape_mean[i]), scale = exp(ret_df$log_scale_mean[i]), 1, 0)
         ret_df$NMR[i] <- rcpp_F_loglogistic(1, shape = exp(ret_df$log_shape_mean[i]), scale = exp(ret_df$log_scale_mean[i]), 1, 0)


### PR DESCRIPTION
Add "NMR" and "IMR" columns in output.

Another option would be to do something like this: 
```
F_loglogistic <- function(x, shape, scale) expit(shape*log(x/scale))
ret_df$U5MR <- F_loglogistic(60, exp(ret_df$log_shape_mean), exp(ret_df$log_scale_mean))
ret_df$NMR <- F_loglogistic(1, exp(ret_df$log_shape_mean), exp(ret_df$log_scale_mean))
ret_df$IMR <- F_loglogistic(12, exp(ret_df$log_shape_mean), exp(ret_df$log_scale_mean))
```
Perhaps that would be faster than looping through every row and more intuitive than the rcpp function? 