### PR TITLE
check if row_ids has any elements

### DIFF
--- a/R/format_dhs.R
+++ b/R/format_dhs.R
@@ -158,12 +158,14 @@ format_dhs <- function(df,
   
   row_ids <- died_after_max
   # instead make them right censored
-  births[row_ids,]$right_censored <- TRUE
-  births[row_ids,]$interval_censored <- FALSE
-  births[row_ids,]$died <- FALSE
-  births[row_ids,]$age_at_censoring <- new_rightcensoringage
-  births[row_ids,]$t0 <- 0
-  births[row_ids,]$t1 <- Inf
+  if (length(row_ids) > 0) {
+    births[row_ids,]$right_censored <- TRUE
+    births[row_ids,]$interval_censored <- FALSE
+    births[row_ids,]$died <- FALSE
+    births[row_ids,]$age_at_censoring <- new_rightcensoringage
+    births[row_ids,]$t0 <- 0
+    births[row_ids,]$t1 <- Inf
+  }
   
   # if a right_censor_time is specified, do that
   if (!is.na(right_censor_time)) {


### PR DESCRIPTION
Bugfix at step where if they died after max_year, right censor them at their age at max year.

Before my periods were not including the survey year. When, in a new run, I extended my settings to include the survey year there were no children fitting this censoring criteria so I got the following error:

```
Error in `$<-.data.frame`(`*tmp*`, right_censored, value = TRUE) : 
  replacement has 1 row, data has 0
```