### PR TITLE
age_at_censoring data.frame to numeric

### DIFF
--- a/R/format_dhs_utils.R
+++ b/R/format_dhs_utils.R
@@ -84,6 +84,9 @@ get_births <- function(dat,
   # for those who did not die: max(age at censoring, 60 months)
   
   whichnotdied <- which(datnew$died == 0)
+  if (class(datnew$age_at_censoring) == "data.frame") {
+    datnew$age_at_censoring <- datnew$age_at_censoring[, date.interview]
+  }
   # EDIT - fix this so that the interval ending with Inf doesn't have a closed right bracket
   datnew$age_interval <- cut(datnew$age_at_censoring, breaks = c(0,month.cut), include.lowest = TRUE, right = FALSE)
   


### PR DESCRIPTION
This change made `get_births` run without throwing an error, but I'm not convinced there isn't still an issue since I got warnings later in the `format_dhs` functions such as the following:

```
>   new_rightcensoringage <- floor(-((ym(paste(births$year_born, 
+     births$month_born, sep = "-")) - ym(paste0(max_year, 
+     "-01")))[died_after_max])/30)
Warning message:
All formats failed to parse. No formats found. 
```

I can send the data I'm working with if you'd like.