### PR TITLE
bugfix check for t_0i less than t_1i with NAs

### DIFF
--- a/R/surv_synthetic.R
+++ b/R/surv_synthetic.R
@@ -164,7 +164,7 @@ surv_synthetic <- function(df,
   }
   
   # Check that t_0i <= t_1i everywhere
-  if(sum(df[,t_0i] <= df[,t_1i]) != nrow(df)) {
+  if(sum(df[, t_0i] > df[, t_1i], na.rm=T) != 0) {
     stop("at least one observation has an interval-censored time where t_0 > t_1")
   }
   


### PR DESCRIPTION
At the point where this check is introduced, not every row in the data.frame has values for `t_0i` and `t_1i`. In the presence of some NAs the sum is NA and the if statement doesn't get a non-NA T/F to evaluate. I've tested the version in this pull request and it seems to work.