### PR TITLE
Updates to ETSP: faster hazard, non-zero c

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ Imports:
     dplyr,
     survey,
     numDeriv,
-    RcppNumerical
+    RcppNumerical,
+    expint
 LinkingTo: 
     Rcpp,
     RcppEigen,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ License: GPL-3 + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Depends:
     magrittr,
     dplyr,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 export(format_dhs)
 export(format_turnbull)
+export(get_CIs)
 export(surv_synthetic)
 export(turnbull)
 importFrom(Rcpp,sourceCpp)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,6 @@
 
 export(format_dhs)
 export(format_turnbull)
-export(get_CIs)
 export(surv_synthetic)
 export(turnbull)
 importFrom(Rcpp,sourceCpp)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,8 +13,8 @@ rcpp_gradient_multi <- function(x_df, log_shapes, log_scales, dist) {
     .Call(`_pssst_rcpp_gradient_multi`, x_df, log_shapes, log_scales, dist)
 }
 
-rcpp_loglik_multi <- function(x_df, num_periods, log_shapes, log_scales, dist, breakpoints, par_period_id) {
-    .Call(`_pssst_rcpp_loglik_multi`, x_df, num_periods, log_shapes, log_scales, dist, breakpoints, par_period_id)
+rcpp_loglik_multi <- function(x_df, num_periods, log_shapes, log_scales, dist, breakpoints, par_period_id, etsp_c = 0) {
+    .Call(`_pssst_rcpp_loglik_multi`, x_df, num_periods, log_shapes, log_scales, dist, breakpoints, par_period_id, etsp_c)
 }
 
 rcpp_F_gengamma <- function(x, alpha, beta, gamma, lower_tail, give_log) {
@@ -49,8 +49,8 @@ rcpp_f_gompertz <- function(x, rate, shape, give_log) {
     .Call(`_pssst_rcpp_f_gompertz`, x, rate, shape, give_log)
 }
 
-rcpp_hazard_integral <- function(lower_bound, upper_bound, log_shape, log_scale_vec, dist, breakpoints) {
-    .Call(`_pssst_rcpp_hazard_integral`, lower_bound, upper_bound, log_shape, log_scale_vec, dist, breakpoints)
+rcpp_hazard_integral <- function(lower_bound, upper_bound, log_shape, log_scale_vec, dist, breakpoints, etsp_c = 0) {
+    .Call(`_pssst_rcpp_hazard_integral`, lower_bound, upper_bound, log_shape, log_scale_vec, dist, breakpoints, etsp_c)
 }
 
 rcpp_turnbull <- function(niter, t0, t1, lefttrunc, righttrunc, weights, set_lower, set_upper) {

--- a/R/surv_synthetic.R
+++ b/R/surv_synthetic.R
@@ -850,18 +850,14 @@ surv_synthetic <- function(df,
       ret_df$IMR <- NA
       ret_df$NMR <- NA
       for (i in 1:nrow(ret_df)) {
-        ret_df$U5MR[i] <- 1 - exp(-H_etsp(0, 60, a = exp(ret_df$log_a_mean[i]), 
-                                          b = exp(ret_df$log_b_mean[i]), 
-                                          c = 0,
-                                          p = exp(ret_df$log_p_mean[i])))
-        ret_df$IMR[i] <- 1 - exp(-H_etsp(0, 12, a = exp(ret_df$log_a_mean[i]), 
-                                          b = exp(ret_df$log_b_mean[i]), 
-                                          c = 0,
-                                          p = exp(ret_df$log_p_mean[i])))
-        ret_df$NMR[i] <- 1 - exp(-H_etsp(0, 1, a = exp(ret_df$log_a_mean[i]), 
-                                          b = exp(ret_df$log_b_mean[i]), 
-                                          c = 0,
-                                          p = exp(ret_df$log_p_mean[i])))
+        MR <- 1 - exp(-H_etsp(0, c(1, 12, 60),
+                               a = exp(ret_df$log_a_mean[i]), 
+                               b = exp(ret_df$log_b_mean[i]), 
+                               c = 0.0002,
+                               p = exp(ret_df$log_p_mean[i])))
+        ret_df$NMR[i] <- MR[1]
+        ret_df$IMR[i] <- MR[2]
+        ret_df$IMR[i] <- MR[3]
       }
       
     } else if (dist == 7) {

--- a/R/surv_synthetic.R
+++ b/R/surv_synthetic.R
@@ -61,6 +61,7 @@
 #' @param init_vals an optional vector of initial values at which to start the optimizer for the 
 #' parameters. Must specify the appropriate number of parameters for the given distribution /
 #' number of periods.
+#' @param etsp_c If dist is etsp, fixed value to use for the c parameter. Default is zero.
 #' @return A list containing: 
 #' \itemize{
 #' \item result: a dataframe of summarized results
@@ -106,7 +107,8 @@ surv_synthetic <- function(df,
                            numerical_grad = FALSE,
                            dist = "weibull",
                            breakpoints = NA,
-                           init_vals = NA) {
+                           init_vals = NA,
+                           etsp_c = 0) {
   
   # error checking
   if (survey & is.null(weights)) {
@@ -853,7 +855,7 @@ surv_synthetic <- function(df,
         MR <- 1 - exp(-H_etsp(0, c(1, 12, 60),
                                a = exp(ret_df$log_a_mean[i]), 
                                b = exp(ret_df$log_b_mean[i]), 
-                               c = 0.0002,
+                               c = etsp_c,
                                p = exp(ret_df$log_p_mean[i])))
         ret_df$NMR[i] <- MR[1]
         ret_df$IMR[i] <- MR[2]

--- a/R/surv_synthetic.R
+++ b/R/surv_synthetic.R
@@ -315,7 +315,8 @@ surv_synthetic <- function(df,
                                             shape_par_ids = 1,
                                             dist = dist,
                                             breakpoints = breakpoints,
-                                            num_periods = n_periods)
+                                            num_periods = n_periods,
+                                            etsp_c = etsp_c)
         }
       } else {
         test_scores <- rcpp_gradient_multi(x_df = df[,c("I_i","A_i","t_i","t_0i","t_1i", a_pi_cols, l_p_cols)] %>% as.data.frame(),
@@ -589,7 +590,8 @@ surv_synthetic <- function(df,
                          breakpoints = breakpoints,
                          num_periods = n_periods,
                          method = "BFGS",
-                         hessian = TRUE)
+                         hessian = TRUE,
+                         etsp_c = etsp_c)
       end_time <- Sys.time()
       end_time - start_time
       
@@ -605,7 +607,8 @@ surv_synthetic <- function(df,
                                             shape_par_ids = 1:n_periods,
                                             dist = dist,
                                             breakpoints = breakpoints,
-                                            num_periods = n_periods)
+                                            num_periods = n_periods,
+                                            etsp_c = etsp_c)
         }
       }
       

--- a/R/surv_synthetic.R
+++ b/R/surv_synthetic.R
@@ -862,7 +862,7 @@ surv_synthetic <- function(df,
                                p = exp(ret_df$log_p_mean[i])))
         ret_df$NMR[i] <- MR[1]
         ret_df$IMR[i] <- MR[2]
-        ret_df$IMR[i] <- MR[3]
+        ret_df$U5MR[i] <- MR[3]
       }
       
     } else if (dist == 7) {

--- a/R/surv_synthetic_utils.R
+++ b/R/surv_synthetic_utils.R
@@ -6,13 +6,14 @@
 #' @param shape_par_ids which pars are shape parameters
 #' @param dist integer denoting which distribution to use
 #' @param num_periods number of periods in dataframe
+#' @param etsp_c if dist is etsp, fixed value to use for the c parameter. Default is zero.
 #' @return negative log likelihood
 #' 
 #' @author Taylor Okonek
 #' @noRd
 #' @keywords internal
 optim_fn <- function(par, data, weights, shape_par_ids, dist, breakpoints,
-                     num_periods) {
+                     num_periods, etsp_c = 0) {
   # weibull
   if (dist == 1) {
     pars_per_period <- length(par[-shape_par_ids]) / num_periods
@@ -78,7 +79,8 @@ optim_fn <- function(par, data, weights, shape_par_ids, dist, breakpoints,
                            log_scales = par[-shape_par_ids], 
                            dist = dist,
                            breakpoints = breakpoints,
-                           par_period_id = par_period_id) 
+                           par_period_id = par_period_id,
+                           etsp_c = etsp_c) 
     ret <- -sum(a * weights)
 
   } 
@@ -93,13 +95,14 @@ optim_fn <- function(par, data, weights, shape_par_ids, dist, breakpoints,
 #' @param shape_par_ids which pars are shape parameters
 #' @param dist integer denoting which distribution to use
 #' @param num_periods numer of periods in dataframe
+#' @param etsp_c if dist is etsp, fixed value to use for the c parameter. Default is zero.
 #' @return negative log likelihood
 #' 
 #' @author Taylor Okonek
 #' @noRd
 #' @keywords internal
 optim_fn_grad <- function(par, data, weights, shape_par_ids, dist,
-                          num_periods, breakpoints) {
+                          num_periods, breakpoints, etsp_c = 0) {
   if (dist == 1) {
     pars_per_period <- length(par[-shape_par_ids]) / num_periods
     par_period_id <- rep(1:num_periods, each = pars_per_period)
@@ -155,7 +158,8 @@ optim_fn_grad <- function(par, data, weights, shape_par_ids, dist,
                                log_scales = par[-shape_par_ids], 
                                dist = dist,
                                breakpoints = breakpoints,
-                               par_period_id = par_period_id) * weights)
+                               par_period_id = par_period_id,
+                               etsp_c = etsp_c) * weights)
     
   }
   return(a)

--- a/R/surv_synthetic_utils.R
+++ b/R/surv_synthetic_utils.R
@@ -343,10 +343,9 @@ h_etsp <- function (x, a, b, c, p) {
 #' @noRd
 #' @keywords internal
 H_etsp <- function(lower, upper, a, b, c, p) {
-  ret <- integrate(h_etsp, lower, upper, a = a, b = b, c = c, p = p)
-  return(ret$value)
+  ret <- -1*a*exp(b*c)*b^(p-1)*(expint::gammainc(1-p, b*(c+upper)) - expint::gammainc(1-p, b*(c+lower)))
+  return(ret)
 }
-H_etsp <- Vectorize(H_etsp)
 
 
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The package currently supports the following parametric distributions:
 * Gompertz
 * Dagum
 * Log-logistic
+* Exponentially-truncated shifted power family
 
 ## Installation
 

--- a/man/pssst.Rd
+++ b/man/pssst.Rd
@@ -2,10 +2,18 @@
 % Please edit documentation in R/pssst-package.R
 \docType{package}
 \name{pssst}
+\alias{pssst-package}
 \alias{pssst}
 \title{pssst: Parametric Survey-weighted Survival models for Synthetic children across Time}
+\description{
+Fit parametric survival models to survey data to estimate finite-population, synthetic child mortality across multiple time periods.
+}
 \section{pssst functions}{
 
 format_dhs
 }
 
+\author{
+\strong{Maintainer}: Taylor Okonek \email{tokonek@uw.edu}
+
+}

--- a/man/surv_synthetic.Rd
+++ b/man/surv_synthetic.Rd
@@ -24,7 +24,8 @@ surv_synthetic(
   numerical_grad = FALSE,
   dist = "weibull",
   breakpoints = NA,
-  init_vals = NA
+  init_vals = NA,
+  etsp_c = 0
 )
 }
 \arguments{
@@ -76,7 +77,7 @@ at the moment.}
 
 \item{dist}{distribution. Currently supports "weibull", "exponential",
 "piecewise_exponential", "gengamma", "lognormal", "gompertz", "etsp" (exponentially-truncated shifted power family),
-"loglogistic"}
+"loglogistic", "dagum"}
 
 \item{breakpoints}{if distribution is "piecewise_exponential", the breakpoints (in months) where
 the distribution should be divided}
@@ -84,6 +85,8 @@ the distribution should be divided}
 \item{init_vals}{an optional vector of initial values at which to start the optimizer for the
 parameters. Must specify the appropriate number of parameters for the given distribution /
 number of periods.}
+
+\item{etsp_c}{If dist is etsp, fixed value to use for the c parameter. Default is zero.}
 }
 \value{
 A list containing:

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -53,8 +53,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // rcpp_loglik_multi
-NumericVector rcpp_loglik_multi(DataFrame x_df, int num_periods, NumericVector log_shapes, NumericVector log_scales, int dist, NumericVector breakpoints, NumericVector par_period_id);
-RcppExport SEXP _pssst_rcpp_loglik_multi(SEXP x_dfSEXP, SEXP num_periodsSEXP, SEXP log_shapesSEXP, SEXP log_scalesSEXP, SEXP distSEXP, SEXP breakpointsSEXP, SEXP par_period_idSEXP) {
+NumericVector rcpp_loglik_multi(DataFrame x_df, int num_periods, NumericVector log_shapes, NumericVector log_scales, int dist, NumericVector breakpoints, NumericVector par_period_id, double etsp_c);
+RcppExport SEXP _pssst_rcpp_loglik_multi(SEXP x_dfSEXP, SEXP num_periodsSEXP, SEXP log_shapesSEXP, SEXP log_scalesSEXP, SEXP distSEXP, SEXP breakpointsSEXP, SEXP par_period_idSEXP, SEXP etsp_cSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -65,7 +65,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type dist(distSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type breakpoints(breakpointsSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type par_period_id(par_period_idSEXP);
-    rcpp_result_gen = Rcpp::wrap(rcpp_loglik_multi(x_df, num_periods, log_shapes, log_scales, dist, breakpoints, par_period_id));
+    Rcpp::traits::input_parameter< double >::type etsp_c(etsp_cSEXP);
+    rcpp_result_gen = Rcpp::wrap(rcpp_loglik_multi(x_df, num_periods, log_shapes, log_scales, dist, breakpoints, par_period_id, etsp_c));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -190,8 +191,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // rcpp_hazard_integral
-double rcpp_hazard_integral(double lower_bound, double upper_bound, double log_shape, NumericVector log_scale_vec, int dist, NumericVector breakpoints);
-RcppExport SEXP _pssst_rcpp_hazard_integral(SEXP lower_boundSEXP, SEXP upper_boundSEXP, SEXP log_shapeSEXP, SEXP log_scale_vecSEXP, SEXP distSEXP, SEXP breakpointsSEXP) {
+double rcpp_hazard_integral(double lower_bound, double upper_bound, double log_shape, NumericVector log_scale_vec, int dist, NumericVector breakpoints, double etsp_c);
+RcppExport SEXP _pssst_rcpp_hazard_integral(SEXP lower_boundSEXP, SEXP upper_boundSEXP, SEXP log_shapeSEXP, SEXP log_scale_vecSEXP, SEXP distSEXP, SEXP breakpointsSEXP, SEXP etsp_cSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -201,7 +202,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericVector >::type log_scale_vec(log_scale_vecSEXP);
     Rcpp::traits::input_parameter< int >::type dist(distSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type breakpoints(breakpointsSEXP);
-    rcpp_result_gen = Rcpp::wrap(rcpp_hazard_integral(lower_bound, upper_bound, log_shape, log_scale_vec, dist, breakpoints));
+    Rcpp::traits::input_parameter< double >::type etsp_c(etsp_cSEXP);
+    rcpp_result_gen = Rcpp::wrap(rcpp_hazard_integral(lower_bound, upper_bound, log_shape, log_scale_vec, dist, breakpoints, etsp_c));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -228,7 +230,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_pssst_rcpp_expand_surv", (DL_FUNC) &_pssst_rcpp_expand_surv, 4},
     {"_pssst_rcpp_expand_surv_helper", (DL_FUNC) &_pssst_rcpp_expand_surv_helper, 3},
     {"_pssst_rcpp_gradient_multi", (DL_FUNC) &_pssst_rcpp_gradient_multi, 4},
-    {"_pssst_rcpp_loglik_multi", (DL_FUNC) &_pssst_rcpp_loglik_multi, 7},
+    {"_pssst_rcpp_loglik_multi", (DL_FUNC) &_pssst_rcpp_loglik_multi, 8},
     {"_pssst_rcpp_F_gengamma", (DL_FUNC) &_pssst_rcpp_F_gengamma, 6},
     {"_pssst_rcpp_f_gengamma", (DL_FUNC) &_pssst_rcpp_f_gengamma, 5},
     {"_pssst_rcpp_F_gompertz", (DL_FUNC) &_pssst_rcpp_F_gompertz, 5},
@@ -237,7 +239,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_pssst_rcpp_F_dagum", (DL_FUNC) &_pssst_rcpp_F_dagum, 6},
     {"_pssst_rcpp_f_dagum", (DL_FUNC) &_pssst_rcpp_f_dagum, 5},
     {"_pssst_rcpp_f_gompertz", (DL_FUNC) &_pssst_rcpp_f_gompertz, 4},
-    {"_pssst_rcpp_hazard_integral", (DL_FUNC) &_pssst_rcpp_hazard_integral, 6},
+    {"_pssst_rcpp_hazard_integral", (DL_FUNC) &_pssst_rcpp_hazard_integral, 7},
     {"_pssst_rcpp_turnbull", (DL_FUNC) &_pssst_rcpp_turnbull, 8},
     {NULL, NULL, 0}
 };

--- a/src/rcpp_loglik_multi.cpp
+++ b/src/rcpp_loglik_multi.cpp
@@ -45,7 +45,7 @@ using namespace Rcpp;
 // p_vec: time period id
 
 // [[Rcpp::export]]
-NumericVector rcpp_loglik_multi(DataFrame x_df, int num_periods, NumericVector log_shapes, NumericVector log_scales, int dist, NumericVector breakpoints, NumericVector par_period_id) {
+NumericVector rcpp_loglik_multi(DataFrame x_df, int num_periods, NumericVector log_shapes, NumericVector log_scales, int dist, NumericVector breakpoints, NumericVector par_period_id, double etsp_c = 0) {
 
   // Convert dataframe to matrix
   NumericMatrix x = testDFtoNM1(x_df);
@@ -110,7 +110,7 @@ NumericVector rcpp_loglik_multi(DataFrame x_df, int num_periods, NumericVector l
               which_vals_counter += 1;
             } 
           }
-          H_i += rcpp_hazard_integral(std::max(a_pi[j], 0.0), std::min(x(i, 2), a_pi[j] + l_p[j]), log_shape_internal[j], which_vals, dist, breakpoints);
+          H_i += rcpp_hazard_integral(std::max(a_pi[j], 0.0), std::min(x(i, 2), a_pi[j] + l_p[j]), log_shape_internal[j], which_vals, dist, breakpoints, etsp_c);
           // Rcout << "cumulative hazard, right-censored : " << H_i << "\n";
           
         }
@@ -138,7 +138,7 @@ NumericVector rcpp_loglik_multi(DataFrame x_df, int num_periods, NumericVector l
             } 
           }
           //Rcout << "inputs t0: " <<  std::max(a_pi[j], 0.0) << "," << std::min(x(i, 3), a_pi[j] + l_p[j]) << ", ";
-          H_i0 += rcpp_hazard_integral(std::max(a_pi[j], 0.0), std::min(x(i, 3), a_pi[j] + l_p[j]), log_shape_internal[j], which_vals, dist, breakpoints);
+          H_i0 += rcpp_hazard_integral(std::max(a_pi[j], 0.0), std::min(x(i, 3), a_pi[j] + l_p[j]), log_shape_internal[j], which_vals, dist, breakpoints, etsp_c);
          // Rcout << "t0 cumulative hazard, interval-censored : " << H_i0 << "\n";
           
         }
@@ -160,7 +160,7 @@ NumericVector rcpp_loglik_multi(DataFrame x_df, int num_periods, NumericVector l
             } 
           }
           //Rcout << "inputs t1: " <<  std::max(a_pi[j], 0.0) << "," << std::min(x(i, 4), a_pi[j] + l_p[j]) << ", logshape=" << log_shape_internal[j] << "whichvals=" << which_vals;
-          H_i1 += rcpp_hazard_integral(std::max(a_pi[j], 0.0), std::min(x(i, 4), a_pi[j] + l_p[j]), log_shape_internal[j], which_vals, dist, breakpoints);
+          H_i1 += rcpp_hazard_integral(std::max(a_pi[j], 0.0), std::min(x(i, 4), a_pi[j] + l_p[j]), log_shape_internal[j], which_vals, dist, breakpoints, etsp_c);
           //Rcout << "t1 cumulative hazard, interval-censored: " << H_i1 << "\n";
         }
       }
@@ -185,7 +185,7 @@ NumericVector rcpp_loglik_multi(DataFrame x_df, int num_periods, NumericVector l
               which_vals_counter += 1;
             } 
           }
-          H_i += rcpp_hazard_integral(std::max(a_pi[j], 0.0), std::min(x(i, 3), a_pi[j] + l_p[j]), log_shape_internal[j], which_vals, dist, breakpoints);
+          H_i += rcpp_hazard_integral(std::max(a_pi[j], 0.0), std::min(x(i, 3), a_pi[j] + l_p[j]), log_shape_internal[j], which_vals, dist, breakpoints, etsp_c);
         }
       }
 

--- a/src/rcpp_loglik_multi_helpers.h
+++ b/src/rcpp_loglik_multi_helpers.h
@@ -326,7 +326,7 @@ double rcpp_hazard_integral(double lower_bound, double upper_bound, double log_s
   // c = 0
   // p = scale_vec[1]
 
-  etsp_haz f(shape_param, scale_vec[0], 0.0, scale_vec[1]);
+  etsp_haz f(shape_param, scale_vec[0], 0.0002, scale_vec[1]);
   double err_est;
   int err_code;
 

--- a/src/rcpp_loglik_multi_helpers.h
+++ b/src/rcpp_loglik_multi_helpers.h
@@ -218,7 +218,7 @@ public:
 // 7 = Log-logistic
 // 8 = Dagum
 // [[Rcpp::export]]
-double rcpp_hazard_integral(double lower_bound, double upper_bound, double log_shape, NumericVector log_scale_vec, int dist, NumericVector breakpoints) {
+double rcpp_hazard_integral(double lower_bound, double upper_bound, double log_shape, NumericVector log_scale_vec, int dist, NumericVector breakpoints, double etsp_c = 0) {
   NumericVector scale_vec = exp(log_scale_vec);
   NumericVector rate_param_vec = 1/scale_vec;
   double shape_param = exp(log_shape);
@@ -326,7 +326,7 @@ double rcpp_hazard_integral(double lower_bound, double upper_bound, double log_s
   // c = 0
   // p = scale_vec[1]
 
-  etsp_haz f(shape_param, scale_vec[0], 0.0002, scale_vec[1]);
+  etsp_haz f(shape_param, scale_vec[0], etsp_c, scale_vec[1]);
   double err_est;
   int err_code;
 


### PR DESCRIPTION
Hi Taylor,

This PR includes (1) a faster hazard function for the ETSP model, and (2) a change to use a non-zero c value based on some MLE work I did using VR data [should probably make this a function argument at some point but I want to start here].

For (1), I found the incomplete gamma function solution to the integral using Wolfram-Alpha and tested that in R. Here is some code I used to test speed:

```

# Current ETSP hazard in pssst
h_etsp <- function (x, a, b, c, p) {
  a * (x + c)^(-p) * exp(-b * x)
}
H_etsp <- function(lower, upper, a, b, c, p) {
  ret <- integrate(h_etsp, lower, upper, a = a, b = b, c = c, p = p)
  return(ret$value)
}
H_etsp <- Vectorize(H_etsp)

# Proposed alternative using incomplete gamma function
H_etsp2 <- function(lower, upper, a, b, c, p) {
  ret <- -1*a*exp(b*c)*b^(p-1)*(expint::gammainc(1-p, b*(c+upper)) - expint::gammainc(1-p, b*(c+lower)))
  return(ret)
}

# Test values
a <- 0.000878
b <- 0.0236
c <- 0.0002
p <- 0.862

# Check they give the same thing within some acceptable margin of error
H_etsp(lower = 0, upper = 60, a, b, c, p)
H_etsp2(lower = 0, upper = 60, a, b, c, p)

# Profile speed
library(profvis)
profvis({
  for (j in 1:100) {
    for (i in 1:60) {
      H_etsp(lower = 0, upper = i, a, b, c, p)
    }
  }
  for (j in 1:100) {
    for (i in 1:60) {
      H_etsp2(lower = 0, upper = i, a, b, c, p)
    }
  }
})
```

Also -- I am noticing that when I try to fit the etsp survival model using this package, either with your old code or my proposed new code, I get some (but not many) of the "a" values here: https://github.com/taylorokonek/pssst/blob/27b88b5b26704f26239ca2cb6ef9a919a354af4c/R/surv_synthetic_utils.R#L75 are infinite, leading to an error. What initial values did you use when you fit the ETSP model? Do you have a good idea for what to do when we get a handful of infinite values here?

Happy to chat about this if you'd prefer for me to explain verbally. Thank you!!