### PR TITLE
DHS I & MICS

### DIFF
--- a/R/format_dhs_utils.R
+++ b/R/format_dhs_utils.R
@@ -21,6 +21,7 @@ get_births <- function(dat,
                 "v001", "v002", "v004", "v005", "v021", "v022", "v023", 
                 "v024", "v025", "v139", "bidx")
   dob <- "b3"
+  
   alive <- "b5"
   age <- "b7"
   exact_age <- "b6"
@@ -28,6 +29,12 @@ get_births <- function(dat,
   # cmc.adjust <- 0
   date.interview <- "v008"
   month.cut <- c(seq(1,24), seq(36,12*100, by = 12))
+  
+  # DHS I is missing v021 (psu), v022 (strata), v023 (other strata variable), v024 (de facto region of residence),
+  # v025 (de facto type of place of residence, i.e. urban/rural), v139 (de jure region of usual residence)
+  # -- these columns aren't critical, so just add as NA
+  missing_cols <- setdiff(c("v021", "v022", "v023", "v024", "v025", "v139"), names(dat))
+  dat[missing_cols] <- NA
   
   # extra interval censoring, if specified
   if (!is.na(intervals[1])) {

--- a/R/format_dhs_utils.R
+++ b/R/format_dhs_utils.R
@@ -21,7 +21,6 @@ get_births <- function(dat,
                 "v001", "v002", "v004", "v005", "v021", "v022", "v023", 
                 "v024", "v025", "v139", "bidx")
   dob <- "b3"
-  
   alive <- "b5"
   age <- "b7"
   exact_age <- "b6"

--- a/R/format_dhs_utils.R
+++ b/R/format_dhs_utils.R
@@ -35,6 +35,12 @@ get_births <- function(dat,
   missing_cols <- setdiff(c("v021", "v022", "v023", "v024", "v025", "v139"), names(dat))
   dat[missing_cols] <- NA
   
+  # if strata is NULL or NA, add empty column
+  if (is.null(strata) || all(is.na(strata))) {
+    dat$strata <- NA
+    strata <- "strata"
+  }
+  
   # extra interval censoring, if specified
   if (!is.na(intervals[1])) {
     seq_remove <- c()

--- a/R/surv_synthetic.R
+++ b/R/surv_synthetic.R
@@ -265,14 +265,17 @@ surv_synthetic <- function(df,
   }
   
   # pivot wider
+  id_cols <- c("individual", c("household", "cluster","strata","weights")[which(survey_cols_include)],
+               "I_i", "A_i", "t_i", "t_0i", "t_1i")
   df <- df %>%
-    tidyr::pivot_wider(id_cols = c(individual, household, cluster, strata, weights, I_i, A_i, t_i, t_0i, t_1i),
+    tidyr::pivot_wider(id_cols = all_of(id_cols),
                        names_from = p,
                        values_from = c(a_pi, l_p))
   
   # get unique combinations of relevant variables, and collapse
+  collapse_cols <- intersect(c("individual", "household", "cluster", "strata"), names(df))
   collapsed_df <- df %>% 
-    dplyr::count(dplyr::select(.,-individual, -household, -cluster, -strata))
+    dplyr::count(dplyr::select(.,-any_of(collapse_cols)))
   
   # get column name indicators for a_pi and l_p
   a_pi_cols <- paste0("a_pi_",period_names)

--- a/R/surv_synthetic_utils.R
+++ b/R/surv_synthetic_utils.R
@@ -79,7 +79,7 @@ optim_fn <- function(par, data, weights, shape_par_ids, dist, breakpoints,
     pars_per_period <- length(par[-shape_par_ids]) / num_periods
     par_period_id <- rep(1:num_periods, each = pars_per_period)
 
-    a <- rcpp_loglik_multi(x_df = data[,-ncols(data)], 
+    a <- rcpp_loglik_multi(x_df = data[,-ncol(data)], 
                            num_periods = num_periods,
                            log_shapes = par[shape_par_ids], 
                            log_scales = par[-shape_par_ids], 


### PR DESCRIPTION
This PR addresses columns missing from DHS I (oldest DHS). We could do a similar thing for MICS but I haven't pushed a commit for that to this PR yet.

Columns missing from DHS I that seem to be required by pssst as currently written: 
- v021 (psu)
- v022 (strata)
- v023 (other strata variable)
- v024 (de facto region of residence)
- v025 (de facto type of place of residence, i.e. urban/rural)
- v139 (de jure region of usual residence)

Columns missing from MICS:
- bidx
- b6

It seems to me that none of these columns are actually used by pssst, just passed into the output, so this PR just adds them as NA. Please let me know if you think I missed something though.