### PR TITLE
Add error for missing information about age at death

### DIFF
--- a/R/format_dhs.R
+++ b/R/format_dhs.R
@@ -131,6 +131,13 @@ format_dhs <- function(df,
     }
   }
   
+  # check for individuals who died who are missing information about date of death
+  missing_data <- df %>% filter(is.na(b7) & is.na(b6) & b5 == "no")
+  n_missing <- nrow(missing_data)
+  if (n_missing > 0) {
+    stop(paste0(nrow(missing_data), " individuals who died do not have age at death."))
+  }
+  
   # call get_births
   births <- get_births(dat = df, 
                        surveyyear = survey_year, 


### PR DESCRIPTION
This is to debug an error that looks like this:
```
 in format data, Error in if ((new_t_1i != temp$t_1i[1]) | (new_t_0i != temp$t_0i[1])) { :
  missing value where TRUE/FALSE needed
```
occurring at this line: https://github.com/taylorokonek/pssst/blob/main/R/format_dhs.R#L337.

In one survey I'm looking at there's one child with NA values for both b6 (exact age at death, i.e. days/months/years depending on age) and b7 (age at death in months) variables. This led to NA values for `new_t_1i` and `new_t_0i`, hence the error. My current thought is to just drop these cases before running the code but to look carefully to make sure there aren't a lot of these rows in any particular survey. Like 1 row should be okay but many would be concerning. Would be cool if we could do some sort of interval censoring but I don't think we even know the death occurred before the fifth birthday.

What do you think?